### PR TITLE
Minor stylistic improvements

### DIFF
--- a/slang_v1/README.txt
+++ b/slang_v1/README.txt
@@ -33,6 +33,22 @@ slang.native is faster.  However, you probably will
 not notice the difference on this project. 
 
 ===============================================
+Running
+===============================================
+
+Once you have built the project locally, you can invoke `slang.byte` directly:
+
+  ./slang.byte <file>
+
+To run the compiled version distributed with the sources, pass it to
+`ocamlrun` as follows:
+
+  ocamlrun slang.byte <file>
+
+(This is due to the OCaml bytecode file format. If you want to investigate,
+look inside the `slang.byte` file.)
+
+===============================================
 Files
 ===============================================
 
@@ -51,5 +67,3 @@ slang.ml       : main file, implementing the command-line for the interpreter an
 interp_0.ml    : The "definitional" interpreter. 
                  slang_v2 will add four interpreters ... 
 
-
-               

--- a/slang_v1/front_end.ml
+++ b/slang_v1/front_end.ml
@@ -1,11 +1,9 @@
 open Lexing 
 
-let verbose = ref false 
-
 let error file action s = 
     Errors.complain ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n") 
 
-let peek m e pp = if !verbose then print_string (m ^ ":\n" ^ (pp e) ^ "\n") else () 
+let peek m e pp = if Option.verbose_front then print_string (m ^ ":\n" ^ (pp e) ^ "\n") else () 
 
 let parse_error file lexbuf = 
     let pos = lexbuf.lex_curr_p in 

--- a/slang_v1/front_end.mli
+++ b/slang_v1/front_end.mli
@@ -1,4 +1,2 @@
 
-val verbose : bool ref 
-
 val front_end : string -> Ast.expr 

--- a/slang_v1/option.ml
+++ b/slang_v1/option.ml
@@ -1,0 +1,28 @@
+(*
+   parse command line options and args
+*)
+let infile         = ref ""
+let verbose        = ref false
+let verbose_front  = ref false
+let run_tests      = ref false
+let use_i0         = ref false
+let set_infile f   = infile := f
+
+let option_spec = [
+     ("-V",    Arg.Set verbose_front, "verbose front end");
+     ("-i0",   Arg.Set use_i0,        "Interpreter 0 (more later ...)");
+     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
+    ]
+let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
+
+(* This does the parsing and *)
+let () = Arg.parse option_spec set_infile usage_msg
+
+(* set immutable versions of the options now that they have been parsed 
+ * Note: this is only to make the interface cleaner. *)
+let infile        = !infile
+let verbose       = !verbose
+let verbose_front = !verbose_front
+let run_tests     = !run_tests
+let use_i0        = !use_i0
+

--- a/slang_v1/option.ml
+++ b/slang_v1/option.ml
@@ -25,4 +25,3 @@ let verbose       = !verbose
 let verbose_front = !verbose_front
 let run_tests     = !run_tests
 let use_i0        = !use_i0
-

--- a/slang_v1/option.mli
+++ b/slang_v1/option.mli
@@ -1,0 +1,7 @@
+
+(* These are all the options parsed by the module *)
+val infile: string
+val verbose: bool
+val verbose_front: bool
+val run_tests: bool
+val use_i0: bool

--- a/slang_v1/slang.ml
+++ b/slang_v1/slang.ml
@@ -7,28 +7,6 @@ Timothy G. Griffin (tgg22@cam.ac.uk)
 
 (*  This is the main file. *) 
 
-(* 
-   parse command line options and args 
-*) 
-let infile         = ref ""
-let verbose        = ref false
-let verbose_front  = ref false
-let run_tests      = ref false
-let use_i0         = ref false
-let set_infile f   = infile := f 
-
-let option_spec = [
-     ("-V",    Arg.Set verbose_front, "verbose front end"); 
-     ("-i0",   Arg.Set use_i0,        "Interpreter 0 (more later ...)"); 
-     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
-    ] 
-let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
-
-let _ = Arg.parse option_spec set_infile usage_msg
-
-(* set all verbosity flags *) 
-let _ = if !verbose_front then Front_end.verbose := true else () 
-
 let error file action s = print_string ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
 
 let fatal_error file action s = let _ = error file action s in exit(-1) 
@@ -43,13 +21,14 @@ let wrap file e interpret msg =
 
 let i0 (file, e)   = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0" 
 let interpreters = [
-    (* use-flag, the interpreter, a description string *) 
-    (!use_i0,       i0,   "Interpreter 0")] 
+   (* use-flag, the interpreter, a description string *) 
+   (Option.use_i0,       i0,   "Interpreter 0");
+] 
 
 let show_output describe string_out = 
-    if !run_tests
+    if Option.run_tests
     then () 
-    else let _ = if !verbose then print_string ("\n" ^ describe ^ " : \n") else ()
+    else let _ = if Option.verbose then print_string ("\n" ^ describe ^ " : \n") else ()
          in print_string ("output> " ^ string_out ^ "\n")
 
 (* used for -t option *) 
@@ -79,21 +58,23 @@ let rec run_interpreters file e expected_option = function
       else run_interpreters file e expected_option rest 
    
 (* process_inputs : runs all (flagged) interpreters on all inputs *) 
+let process_input file expected =
+   try
+      let e = Front_end.front_end file in
+      run_interpreters file e expected interpreters
+   with
+      Errors.Error s -> error file "Front_end" s
 let rec process_inputs = function 
-       | [] -> () 
-       | (file, expected) :: rest -> 
-          let e_opt = try Some (Front_end.front_end file)
-                      with Errors.Error s -> let _ = error file "Front End" s in None  
-          in let _ = match e_opt with 
-                    | Some e ->  run_interpreters file e expected interpreters 
-                    | None -> () 
-          in process_inputs rest 
+   | [] -> () 
+   | (file, expected) :: rest -> 
+         process_input file expected;
+         process_inputs rest
  
 let _ = process_inputs 
-        (if !run_tests 
+        (if Option.run_tests
         then (try Tests.get_all_tests () 
               with Errors.Error s -> fatal_error "tests/" "Test.get_all_tests" s)
-        else [(!infile, None)])
+        else [(Option.infile, None)])
             
 
 

--- a/slang_v1/slang.ml
+++ b/slang_v1/slang.ml
@@ -1,81 +1,92 @@
 (**************************************
 Compiler Construction 2016
-Computer Laboratory 
-University of Cambridge 
-Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
+Computer Laboratory
+University of Cambridge
+Timothy G. Griffin (tgg22@cam.ac.uk)
+*****************************************)
 
-(*  This is the main file. *) 
+(*  This is the main file. *)
 
 let error file action s = print_string ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
 
-let fatal_error file action s = let _ = error file action s in exit(-1) 
+let fatal_error file action s =
+   error file action s;
+   exit(-1)
 
-(* bind interpreters *) 
-(* each interpreter i_ has type "(string * Ast.expr) -> string option" *) 
+(* bind interpreters *)
+(* each interpreter i_ has type "(string * Ast.expr) -> string option" *)
 
-let wrap file e interpret msg = 
+let wrap file e interpret msg =
     try Some(interpret e)
-    with Errors.Error s -> let _ = error file msg s in None 
-       | exc -> fatal_error file msg ("Exception: " ^ (Printexc.to_string exc))
+    with
+        | Errors.Error s ->
+            error file msg s;
+            None
+        | exc -> fatal_error file msg ("Exception: " ^ (Printexc.to_string exc))
 
-let i0 (file, e)   = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0" 
+let i0 (file, e) = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0"
+
 let interpreters = [
-   (* use-flag, the interpreter, a description string *) 
-   (Option.use_i0,       i0,   "Interpreter 0");
-] 
+   (* use-flag, the interpreter, a description string *)
+   (Option.use_i0, i0, "Interpreter 0");
+]
 
-let show_output describe string_out = 
+let show_output describe string_out =
     if Option.run_tests
-    then () 
-    else let _ = if Option.verbose then print_string ("\n" ^ describe ^ " : \n") else ()
-         in print_string ("output> " ^ string_out ^ "\n")
+    then ()
+    else begin
+       (if Option.verbose
+       then print_string ("\n" ^ describe ^ " : \n")
+       else ()
+       );
+       print_string ("output> " ^ string_out ^ "\n")
+    end
 
-(* used for -t option *) 
-let check_expected describe file string_out = function 
-  | None -> () 
-  | Some expected -> 
-      if string_out = expected 
-      then () 
+(* used for -t option *)
+let check_expected describe file string_out = function
+  | None -> ()
+  | Some expected ->
+      if string_out = expected
+      then ()
       else error file "testing" (
               describe ^ " computed " ^ string_out
-	      ^ ", but expected " ^ expected)  
+	      ^ ", but expected " ^ expected)
 
-(* runs all interpreters on expression e : Ast.expr. 
-   If expected_option = Some (expected), then 
-   checks if the correct result was computed (silent otherwise). 
-*) 
-let rec run_interpreters file e expected_option = function 
-    | [] -> () 
-    | (use, interp, describe) :: rest -> 
-      if use 
-      then (match interp(file, e) with 
-           | None -> run_interpreters file e expected_option rest 
-           | Some string_out -> 
-              let _ = show_output describe string_out 
-              in let _ = check_expected describe file string_out expected_option 
+(* runs all interpreters on expression e : Ast.expr.
+   If expected_option = Some (expected), then
+   checks if the correct result was computed (silent otherwise).
+*)
+let rec run_interpreters file e expected_option = function
+    | [] -> ()
+    | (use, interp, describe) :: rest ->
+      if use
+      then (match interp(file, e) with
+           | None -> run_interpreters file e expected_option rest
+           | Some string_out ->
+              let _ = show_output describe string_out
+              in let _ = check_expected describe file string_out expected_option
               in run_interpreters file e expected_option rest )
-      else run_interpreters file e expected_option rest 
-   
-(* process_inputs : runs all (flagged) interpreters on all inputs *) 
+      else run_interpreters file e expected_option rest
+
+(* process_inputs : runs all (flagged) interpreters on all inputs *)
 let process_input file expected =
    try
       let e = Front_end.front_end file in
       run_interpreters file e expected interpreters
    with
       Errors.Error s -> error file "Front_end" s
-let rec process_inputs = function 
-   | [] -> () 
-   | (file, expected) :: rest -> 
+let rec process_inputs = function
+   | [] -> ()
+   | (file, expected) :: rest ->
          process_input file expected;
          process_inputs rest
- 
-let _ = process_inputs 
+
+let _ = process_inputs
         (if Option.run_tests
-        then (try Tests.get_all_tests () 
+        then (try Tests.get_all_tests ()
               with Errors.Error s -> fatal_error "tests/" "Test.get_all_tests" s)
         else [(Option.infile, None)])
-            
+
 
 
 

--- a/slang_v2/front_end.ml
+++ b/slang_v2/front_end.ml
@@ -1,11 +1,9 @@
 open Lexing 
 
-let verbose = ref false 
-
 let error file action s = 
     Errors.complain ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n") 
 
-let peek m e pp = if !verbose then print_string (m ^ ":\n" ^ (pp e) ^ "\n") else () 
+let peek m e pp = if Option.verbose then print_string (m ^ ":\n" ^ (pp e) ^ "\n") else () 
 
 let parse_error file lexbuf = 
     let pos = lexbuf.lex_curr_p in 

--- a/slang_v2/front_end.mli
+++ b/slang_v2/front_end.mli
@@ -1,4 +1,2 @@
 
-val verbose : bool ref 
-
 val front_end : string -> Ast.expr 

--- a/slang_v2/interp_0.mli
+++ b/slang_v2/interp_0.mli
@@ -1,6 +1,4 @@
 
-val verbose : bool ref 
-
 type address 
 
 

--- a/slang_v2/interp_1.ml
+++ b/slang_v2/interp_1.ml
@@ -17,8 +17,6 @@ open Ast
 
 let complain = Errors.complain
 
-let verbose = ref false 
-
 type address = int 
 
 type value = 
@@ -200,9 +198,7 @@ let string_of_state = function
                ^ (string_of_value v) ^ ")"
 
 
-let heap_max = ref 1000 
-
-let heap  = Array.make !heap_max (INT 0)
+let heap  = Array.make Option.heap_max (INT 0)
 
 let next_address = ref 0 
 
@@ -267,7 +263,7 @@ let step = function
  | state -> complain ("step : malformed state = " ^ (string_of_state state) ^ "\n")
 
 let rec driver n state = 
-  let _ = if !verbose 
+  let _ = if Option.verbose 
           then print_string ("\nstate " ^ (string_of_int n) ^ " = \n" ^ (string_of_state state) ^ "\n")
           else () 
   in match state with 

--- a/slang_v2/interp_1.mli
+++ b/slang_v2/interp_1.mli
@@ -1,6 +1,3 @@
-val verbose : bool ref 
-
-val heap_max : int ref 
 
 type address = int 
 

--- a/slang_v2/interp_2.ml
+++ b/slang_v2/interp_2.ml
@@ -20,10 +20,6 @@ open Ast
 
 let complain = Errors.complain
 
-let heap_max = ref 1000 
-
-let verbose = ref false 
-
 type address = int 
 
 type var = string 
@@ -77,7 +73,7 @@ type state = code * env_value_stack
 
 (* The heap *) 
 
-let heap  = Array.make !heap_max (INT 0)
+let heap  = Array.make Option.heap_max (INT 0)
 
 let next_address = ref 0 
 
@@ -154,7 +150,7 @@ let string_of_state (c, evs) =
 
 (* allocate a new location in the heap *) 
 let allocate () = 
-    if !next_address < !heap_max 
+    if !next_address < Option.heap_max 
     then let a = !next_address in (next_address := a + 1; a) 
     else complain "runtime error: heap kaput"
 
@@ -265,7 +261,7 @@ let step = function
  | state -> complain ("step : bad state = " ^ (string_of_state state) ^ "\n")
 
 let rec driver n state = 
-  let _ = if !verbose 
+  let _ = if Option.verbose 
           then print_string ("\nState " ^ (string_of_int n) 
                              ^ " : " ^ (string_of_state state) ^ "\n")
           else () 
@@ -323,7 +319,7 @@ let rec compile = function
 (* interpret : expr -> value *) 
 let interpret e = 
     let c = compile e in 
-    let _ = if !verbose 
+    let _ = if Option.verbose 
             then print_string("Compile code =\n" ^ (string_of_code c) ^ "\n")
             else () 
     in driver 1 (c, [])

--- a/slang_v2/interp_2.mli
+++ b/slang_v2/interp_2.mli
@@ -1,8 +1,4 @@
 
-val verbose : bool ref 
-
-val heap_max : int ref 
-
 type address = int 
 
 type var = string 

--- a/slang_v2/interp_3.ml
+++ b/slang_v2/interp_3.ml
@@ -20,8 +20,6 @@ open Ast
 
 let complain = Errors.complain
 
-let verbose = ref false 
-
 type address = int 
 
 type label = string 
@@ -180,9 +178,7 @@ let string_of_installed_code ()  =
 
 let get_instruction cp = Array.get !installed cp
 
-let heap_max = ref 1000 
-
-let heap  = Array.make !heap_max (INT 0)
+let heap  = Array.make Option.heap_max (INT 0)
 
 let next_address = ref 0 
 
@@ -370,13 +366,13 @@ let compile e =
     let result = c @               (* body of program *) 
                    [HALT]          (* stop the interpreter *) 
                    @ defs in       (* the function definitions *) 
-    let _ = if !verbose 
+    let _ = if Option.verbose 
             then print_string ("\nCompiled Code = \n" ^ (string_of_code result))
             else () 
     in result 
 
 let rec driver n state = 
-  let _ = if !verbose 
+  let _ = if Option.verbose 
           then print_string ("\nstate " ^ (string_of_int n) ^ ":" ^ (string_of_state state) ^ "\n")
           else () 
   in match state with 
@@ -417,7 +413,7 @@ let rec find lab = function
 let interpret e = 
     let c = compile e in 
     let _ = installed := load c in 
-    let _ = if !verbose 
+    let _ = if Option.verbose 
             then print_string ("\nInstalled Code = \n" ^ (string_of_installed_code()))
             else () 
     (* set the code pointer to 0 *) 

--- a/slang_v2/interp_3.mli
+++ b/slang_v2/interp_3.mli
@@ -1,8 +1,4 @@
 
-val verbose : bool ref 
-
-val heap_max : int ref 
-
 type address = int 
 
 type label = string 

--- a/slang_v2/jargon.ml
+++ b/slang_v2/jargon.ml
@@ -1,11 +1,6 @@
 
 open Ast 
 
-let verbose = ref false 
-
-let stack_max = ref 1000
-let heap_max = ref 1000
-
 type code_index = int 
 type stack_index = int 
 type heap_index = int 
@@ -511,7 +506,7 @@ let step vm =
 (* DRIVER *) 
 
 let rec driver n vm = 
-    let _ = if !verbose 
+    let _ = if Option.verbose 
             then print_string ("========== state " ^ (string_of_int n) ^ 
                                " ==========\n" ^ (string_of_state vm) ^ "\n") 
             else () 
@@ -547,15 +542,15 @@ let load instr_list =
 
 let initial_state l = 
   let (code_array, c_bound) = load l in 
-  let _ = if !verbose 
+  let _ = if Option.verbose 
           then print_string ("\nInstalled Code = \n" ^ (string_of_installed_code(code_array, c_bound))) 
           else () in 
   { 
-    stack_bound = !stack_max; 
-    heap_bound = !heap_max; 
+    stack_bound = Option.stack_max; 
+    heap_bound = Option.heap_max; 
     code_bound = c_bound; 
-    stack = Array.make !stack_max (STACK_INT 0);
-    heap = Array.make !heap_max (HEAP_INT 0);
+    stack = Array.make Option.stack_max (STACK_INT 0);
+    heap = Array.make Option.heap_max (HEAP_INT 0);
     code = code_array; 
     sp = 0; 
     fp = 0; 
@@ -713,7 +708,7 @@ let compile e =
     let result = c          (* body of program *) 
                  @ [HALT]   (* stop the interpreter *) 
                  @ defs in  (* the function definitions *) 
-    let _ = if !verbose 
+    let _ = if Option.verbose 
             then print_string ("\nCompiled Code = \n" ^ (string_of_listing result))
             else () 
     in result 

--- a/slang_v2/jargon.mli
+++ b/slang_v2/jargon.mli
@@ -1,9 +1,4 @@
 
-val verbose : bool ref 
-
-val stack_max : int ref 
-val heap_max : int ref 
-
 type code_index = int 
 type stack_index = int 
 type heap_index = int 

--- a/slang_v2/option.ml
+++ b/slang_v2/option.ml
@@ -1,0 +1,56 @@
+(*
+   parse command line options and args
+*)
+let infile         = ref ""
+let verbose        = ref false
+let verbose_front  = ref false
+let run_tests      = ref false
+let use_i0         = ref false
+let use_i1         = ref false
+let use_i2         = ref false
+let use_i3         = ref false
+let use_i4         = ref false
+let use_all ()     =
+   use_i0 := true;
+   use_i1 := true;
+   use_i2 := true;
+   use_i3 := true;
+   use_i4 := true
+let show_compiled  = ref false
+let set_infile f   = infile := f
+let stack_max      = ref 1000
+let heap_max       = ref 1000
+
+let option_spec = [
+     ("-V",    Arg.Set verbose_front, "verbose front end");
+     ("-v",    Arg.Set verbose,       "verbose interpreter(s)");
+     ("-c",    Arg.Set show_compiled, "show compiled code (but don't run it)");
+     ("-i0",   Arg.Set use_i0,        "Interpreter 0");
+     ("-i1",   Arg.Set use_i1,        "Interpreter 1" );
+     ("-i2",   Arg.Set use_i2,        "Interpreter 2" );
+     ("-i3",   Arg.Set use_i3,        "Interpreter 3" );
+     ("-i4",   Arg.Set use_i4,        "Jargon VM" );
+     ("-all",  Arg.Unit use_all,      "all interpreters");
+     ("-stackmax",  Arg.Set_int stack_max, "set max stack size (default = 1000)");
+     ("-heapmax",  Arg.Set_int heap_max, "set max heap size (default = 1000)");
+     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
+    ]
+let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
+
+(* This does the parsing and *)
+let () = Arg.parse option_spec set_infile usage_msg
+
+(* set immutable versions of the options now that they have been parsed 
+ * Note: this is only to make the interface cleaner. *)
+let infile        = !infile
+let verbose       = !verbose
+let verbose_front = !verbose_front
+let run_tests     = !run_tests
+let use_i0        = !use_i0
+let use_i1        = !use_i1
+let use_i2        = !use_i2
+let use_i3        = !use_i3
+let use_i4        = !use_i4
+let show_compiled = !show_compiled
+let stack_max     = !stack_max
+let heap_max      = !heap_max

--- a/slang_v2/option.mli
+++ b/slang_v2/option.mli
@@ -1,0 +1,14 @@
+
+(* These are all the options parsed by the module *)
+val infile: string
+val verbose: bool
+val verbose_front: bool
+val run_tests: bool
+val use_i0: bool
+val use_i1: bool
+val use_i2: bool
+val use_i3: bool
+val use_i4: bool
+val show_compiled: bool
+val stack_max: int
+val heap_max: int

--- a/slang_v2/slang.ml
+++ b/slang_v2/slang.ml
@@ -1,159 +1,109 @@
 (**************************************
 Compiler Construction 2016
-Computer Laboratory 
-University of Cambridge 
-Timothy G. Griffin (tgg22@cam.ac.uk) 
-*****************************************) 
+Computer Laboratory
+University of Cambridge
+Timothy G. Griffin (tgg22@cam.ac.uk)
+*****************************************)
 
-(*  This is the main file. *) 
-
-(* 
-   parse command line options and args 
-*) 
-let infile         = ref ""
-let verbose        = ref false
-let verbose_front  = ref false
-let run_tests      = ref false
-let use_i0         = ref false
-let use_i1         = ref false
-let use_i2         = ref false
-let use_i3         = ref false
-let use_i4         = ref false
-let use_all        = ref false
-let show_compiled  = ref false
-let set_infile f   = infile := f 
-let set_stack_max m = Jargon.stack_max := m
-let set_heap_max m = (Interp_1.heap_max := m; 
-                      Interp_2.heap_max := m;
-                      Interp_3.heap_max := m;
-                      Jargon.heap_max := m 
-                      )
-
-let option_spec = [
-     ("-V",    Arg.Set verbose_front, "verbose front end"); 
-     ("-v",    Arg.Set verbose,       "verbose interpreter(s)"); 
-     ("-c",    Arg.Set show_compiled, "show compiled code (but don't run it)"); 
-     ("-i0",   Arg.Set use_i0,        "Interpreter 0"); 
-     ("-i1",   Arg.Set use_i1,        "Interpreter 1" ); 
-     ("-i2",   Arg.Set use_i2,        "Interpreter 2" ); 
-     ("-i3",   Arg.Set use_i3,        "Interpreter 3" ); 
-     ("-i4",   Arg.Set use_i4,        "Jargon VM" ); 
-     ("-all",  Arg.Set use_all,       "all interpreters"); 
-     ("-stackmax",  Arg.Int (set_stack_max), "set max stack size (default = 1000)"); 
-     ("-heapmax",  Arg.Int (set_heap_max), "set max heap size (default = 1000)"); 
-     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
-    ] 
-let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
-
-let _ = Arg.parse option_spec set_infile usage_msg
-
-let _ = if !use_all 
-        then (use_i0     := true; 
-	      use_i1     := true; 
-	      use_i2     := true; 
-	      use_i3     := true; 
-	      use_i4     := true; 
-             )
-        else ()
-
-(* set all verbosity flags *) 
-let _ = if !verbose_front then Front_end.verbose := true else () 
-let _ = if !verbose 
-        then (
-              Interp_0.verbose := true; 
-              Interp_1.verbose := true; 
-              Interp_2.verbose := true; 
-              Interp_3.verbose := true; 
-              Jargon.verbose := true;
-             )
-        else () 
+(*  This is the main file. *)
 
 let error file action s = print_string ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n")
 
-let fatal_error file action s = let _ = error file action s in exit(-1) 
+let fatal_error file action s =
+   error file action s;
+   exit(-1)
 
-         
-(* bind interpreters *) 
-(* each interpreter i_ has type "(string * Ast.expr) -> string option" *) 
+(* bind interpreters *)
+(* each interpreter i_ has type "(string * Ast.expr) -> string option" *)
 
-let wrap file e interpret msg = 
+let wrap file e interpret msg =
     try Some(interpret e)
-    with Errors.Error s -> let _ = error file msg s in None 
-       | exc -> let _ = error file msg ("Exception: " ^ (Printexc.to_string exc)) in None 
+    with
+        | Errors.Error s ->
+            error file msg s;
+            None
+        | exc -> fatal_error file msg ("Exception: " ^ (Printexc.to_string exc))
 
-let i0 (file, e)   = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0" 
-let i1 (file, e)   = wrap file e (fun x -> Interp_1.string_of_value (Interp_1.interpret x)) "Interpreter 1" 
-let i2 (file, e)   = wrap file e (fun x -> Interp_2.string_of_value (Interp_2.interpret x)) "Interpreter 2" 
-let i3 (file, e)   = wrap file e (fun x -> Interp_3.string_of_value (Interp_3.interpret x)) "Interpreter 3" 
-let i4 (file, e)   = wrap file e (fun x -> Jargon.string_of_value (Jargon.interpret x)) "Jargon VM" 
+let i0 (file, e)   = wrap file e (fun x -> Interp_0.string_of_value (Interp_0.interpret_top_level x)) "Interpreter 0"
+let i1 (file, e)   = wrap file e (fun x -> Interp_1.string_of_value (Interp_1.interpret x)) "Interpreter 1"
+let i2 (file, e)   = wrap file e (fun x -> Interp_2.string_of_value (Interp_2.interpret x)) "Interpreter 2"
+let i3 (file, e)   = wrap file e (fun x -> Interp_3.string_of_value (Interp_3.interpret x)) "Interpreter 3"
+let i4 (file, e)   = wrap file e (fun x -> Jargon.string_of_value (Jargon.interpret x)) "Jargon VM"
 
-(* show compiled code *) 
-let i2cc (file, e)   = let _ = print_string (Interp_2.string_of_code (Interp_2.compile e)) in None 
-let i3cc (file, e)   = let _ = print_string (Interp_3.string_of_code (Interp_3.compile e)) in None 
-let i4cc (file, e)   = let _ = print_string (Jargon.string_of_listing (Jargon.compile e)) in None 
+(* show compiled code *)
+let i2cc (file, e)   = let _ = print_string (Interp_2.string_of_code (Interp_2.compile e)) in None
+let i3cc (file, e)   = let _ = print_string (Interp_3.string_of_code (Interp_3.compile e)) in None
+let i4cc (file, e)   = let _ = print_string (Jargon.string_of_listing (Jargon.compile e)) in None
 
 
 let interpreters = [
-    (* use-flag,  the action, a description string *) 
-    (!use_i0,                        i0,   "Interpreter 0");
-    (!use_i1,                        i1,   "Interpreter 1");
-    (!use_i2 && not(!show_compiled), i2,   "Interpreter 2");
-    (!show_compiled && !use_i2     , i2cc, "Interpreter 2, compiled code");
-    (!use_i3 && not(!show_compiled), i3,   "Interpreter 3"); 
-    (!show_compiled && !use_i3     , i3cc, "Interpreter 3, compiled code");
-    (!use_i4 && not(!show_compiled), i4,   "Jargon VM"    ); 
-    (!show_compiled && !use_i4     , i4cc, "Jargon, compiled code")
-] 
+    (* use-flag,  the action, a description string *)
+    (Option.use_i0,                              i0,   "Interpreter 0");
+    (Option.use_i1,                              i1,   "Interpreter 1");
+    (Option.use_i2 && not(Option.show_compiled), i2,   "Interpreter 2");
+    (Option.show_compiled && Option.use_i2     , i2cc, "Interpreter 2, compiled code");
+    (Option.use_i3 && not(Option.show_compiled), i3,   "Interpreter 3");
+    (Option.show_compiled && Option.use_i3     , i3cc, "Interpreter 3, compiled code");
+    (Option.use_i4 && not(Option.show_compiled), i4,   "Jargon VM"    );
+    (Option.show_compiled && Option.use_i4     , i4cc, "Jargon, compiled code")
+]
 
-let show_output describe string_out = 
-    if !run_tests
-    then () 
-    else let _ = if !verbose then print_string ("\n" ^ describe ^ " : \n") else ()
-         in print_string ("output> " ^ string_out ^ "\n")
+let show_output describe string_out =
+    if Option.run_tests
+    then ()
+    else begin
+       (if Option.verbose
+       then print_string ("\n" ^ describe ^ " : \n")
+       else ()
+       );
+       print_string ("output> " ^ string_out ^ "\n")
+    end
 
-(* used for -t option *) 
-let check_expected describe file string_out = function 
-  | None -> () 
-  | Some expected -> 
-      if string_out = expected 
-      then () 
+(* used for -t option *)
+let check_expected describe file string_out = function
+  | None -> ()
+  | Some expected ->
+      if string_out = expected
+      then ()
       else error file "testing" (
               describe ^ " computed " ^ string_out
-	      ^ ", but expected " ^ expected)  
+	      ^ ", but expected " ^ expected)
 
-(* runs all interpreters on expression e : Ast.expr. 
-   If expected_option = Some (expected), then 
-   checks if the correct result was computed (silent otherwise). 
-*) 
-let rec run_interpreters file e expected_option = function 
-    | [] -> () 
-    | (use, interp, describe) :: rest -> 
-      if use 
-      then (match interp(file, e) with 
-           | None -> run_interpreters file e expected_option rest 
-           | Some string_out -> 
-              let _ = show_output describe string_out 
-              in let _ = check_expected describe file string_out expected_option 
+(* runs all interpreters on expression e : Ast.expr.
+   If expected_option = Some (expected), then
+   checks if the correct result was computed (silent otherwise).
+*)
+let rec run_interpreters file e expected_option = function
+    | [] -> ()
+    | (use, interp, describe) :: rest ->
+      if use
+      then (match interp(file, e) with
+           | None -> run_interpreters file e expected_option rest
+           | Some string_out ->
+              let _ = show_output describe string_out
+              in let _ = check_expected describe file string_out expected_option
               in run_interpreters file e expected_option rest )
-      else run_interpreters file e expected_option rest 
-   
-(* process_inputs : runs all (flagged) interpreters on all inputs *) 
-let rec process_inputs = function 
-       | [] -> () 
-       | (file, expected) :: rest -> 
-          let e_opt = try Some (Front_end.front_end file)
-                      with Errors.Error s -> let _ = error file "Front End" s in None  
-          in let _ = match e_opt with 
-                    | Some e ->  run_interpreters file e expected interpreters 
-                    | None -> () 
-          in process_inputs rest 
- 
-let _ = process_inputs 
-        (if !run_tests 
-        then (try Tests.get_all_tests () 
+      else run_interpreters file e expected_option rest
+
+(* process_inputs : runs all (flagged) interpreters on all inputs *)
+let process_input file expected =
+   try
+      let e = Front_end.front_end file in
+      run_interpreters file e expected interpreters
+   with
+      Errors.Error s -> error file "Front_end" s
+let rec process_inputs = function
+   | [] -> ()
+   | (file, expected) :: rest ->
+         process_input file expected;
+         process_inputs rest
+
+let _ = process_inputs
+        (if Option.run_tests
+        then (try Tests.get_all_tests ()
               with Errors.Error s -> fatal_error "tests/" "Test.get_all_tests" s)
-        else [(!infile, None)])
-            
+        else [(Option.infile, None)])
+
 
 
 


### PR DESCRIPTION
Changes include:
- using a separate `Option` module to manage command line and such
- un-nesting in the `process_inputs` function by calling a `process_input` (notice the singular) auxiliary function
- section of the `README` about running the program (with mention of `ocamlrun` wrapper)

(Merging this should just be clicking a green button somewhere on this very page. Possibly following a link to the proper page is necessary depending where you are. If you disagree with some changes let me know and I can reverse/improve.)

If accepted, I will do similar changes for v2.
