### PR TITLE
Added a tree version of pretty printing

### DIFF
--- a/slang/front_end.ml
+++ b/slang/front_end.ml
@@ -3,7 +3,7 @@ open Lexing
 let error file action s = 
     Errors.complain ("\nERROR in " ^ file ^ " with " ^ action ^ " : " ^ s ^ "\n") 
 
-let peek m e pp = if Option.verbose_front then print_string (m ^ ":\n" ^ (pp e) ^ "\n") else () 
+let peek m e pp = if Option.verbose_front then print_string (m ^ ":\n" ^ (if Option.verbose_tree then Pptree.pp_no_bracket else (fun x -> x)) (pp e)  ^ "\n") else () 
 
 let parse_error file lexbuf = 
     let pos = lexbuf.lex_curr_p in 

--- a/slang/option.ml
+++ b/slang/option.ml
@@ -4,6 +4,7 @@
 let infile         = ref ""
 let verbose        = ref false
 let verbose_front  = ref false
+let verbose_tree  = ref false
 let run_tests      = ref false
 let use_i0         = ref false
 let use_i1         = ref false
@@ -24,6 +25,7 @@ let heap_max       = ref 1000
 let option_spec = [
      ("-V",    Arg.Set verbose_front, "verbose front end");
      ("-v",    Arg.Set verbose,       "verbose interpreter(s)");
+     ("-T",    Arg.Set verbose_tree,       "verbose output in the form of tree (currently only frontend)");
      ("-c",    Arg.Set show_compiled, "show compiled code (but don't run it)");
      ("-i0",   Arg.Set use_i0,        "Interpreter 0");
      ("-i1",   Arg.Set use_i1,        "Interpreter 1" );
@@ -45,6 +47,7 @@ let () = Arg.parse option_spec set_infile usage_msg
 let infile        = !infile
 let verbose       = !verbose
 let verbose_front = !verbose_front
+let verbose_tree = !verbose_tree
 let run_tests     = !run_tests
 let use_i0        = !use_i0
 let use_i1        = !use_i1

--- a/slang/option.mli
+++ b/slang/option.mli
@@ -3,6 +3,7 @@
 val infile: string
 val verbose: bool
 val verbose_front: bool
+val verbose_tree: bool
 val run_tests: bool
 val use_i0: bool
 val use_i1: bool

--- a/slang/pptree.ml
+++ b/slang/pptree.ml
@@ -1,0 +1,26 @@
+(* Pretty Printing without brackets*)
+let string_replace_char s c_from c_to =
+  let char_map i =
+    if s.[i] = c_from
+    then c_to
+    else s.[i] in
+  String.init (String.length s) char_map;;
+let tail s = (String.sub s 1 ( (String.length s) - 1))
+let pp_no_bracket str =
+  let rec aux output indent_list left =
+    match left with
+    | "" -> output
+    | x -> match x.[0] with
+      | '(' ->
+        let old_indent = List.hd indent_list in
+        let new_indent = (string_replace_char old_indent '-' ' ') ^ "|- " in
+        aux (output ^ "\n" ^ new_indent) (new_indent::indent_list) (tail left)
+      | ',' -> aux (output ^ "\n" ^ (List.hd indent_list)) indent_list (tail left)
+      | ')' -> aux output (List.tl indent_list) (tail left)
+      | ' ' -> aux output indent_list (tail left)
+      | c -> aux (output ^ (Char.escaped c)) indent_list (tail left)
+  in aux "" [""] str
+
+
+(* let test_str = "LetRecFun(fib, (m, If(Op(Var(m), EQI, Integer(0)), Integer(1), If(Op(Var(m), EQI, Integer(1)), Integer(1), Op(App(Var(fib), Op (Var(m), SUB, Integer(1))), ADD, App(Var(fib), Op(Var(m), SUB, Integer(2))))))), App(Var(fib), UnaryOp(READ, Unit)))" *)
+(* let _ = print_string (pp_no_bracket test_str) *)

--- a/slang/pptree.mli
+++ b/slang/pptree.mli
@@ -1,0 +1,1 @@
+val pp_no_bracket : string -> string

--- a/slang/slang.ml
+++ b/slang/slang.ml
@@ -53,7 +53,7 @@ let show_output describe string_out =
     then ()
     else begin
        (if Option.verbose
-       then print_string ("\n" ^ describe ^ " : \n")
+       then print_string ("\n" ^  describe ^ " \n")
        else ()
        );
        print_string ("output> " ^ string_out ^ "\n")


### PR DESCRIPTION
Pretty printing with brackets might not be very readable. I added a tree representation of the structure. It is a string-to-string conversion. (It might take a lot of vertical space). 

Currently only support frontend. Can be easily extended to backend. Can be enabled with "-T" option.