### PR TITLE
Cleanup interpreter 2

### DIFF
--- a/slang/interp_2.ml
+++ b/slang/interp_2.ml
@@ -187,11 +187,6 @@ let lookup_opt (env, x) =
           else aux rest  
       in aux env 
 
-let lookup (env, x) = 
-    match lookup_opt (env, x) with 
-    | None -> complain (x ^ " is not defined!\n")
-    | Some v -> v 
-
 let rec search (evs, x) = 
   match evs with 
   | [] -> complain (x ^ " is not defined!\n")

--- a/slang/interp_2.mli
+++ b/slang/interp_2.mli
@@ -11,7 +11,8 @@ type value =
      | PAIR of value * value 
      | INL of value 
      | INR of value 
-     | CLOSURE of bool * closure    
+     | CLOSURE of closure    
+     | REC_CLOSURE of code
 
 and closure = code * env 
 


### PR DESCRIPTION
The value CLOSURE was previously representing both a recursive and an ordinary closure. This was slightly confusing as a boolean flag was being used to represent which type of closure we were talking about, and there was a redundant place to store environments which recursive closure did not need. So I split it into two different values.